### PR TITLE
Don't use outdated XmlTextWriter

### DIFF
--- a/CdonMarketplace/Utils/SameNamespaceXmlWriter.cs
+++ b/CdonMarketplace/Utils/SameNamespaceXmlWriter.cs
@@ -1,0 +1,79 @@
+﻿using System.Xml;
+
+namespace CdonMarketplace.Utils
+{
+    internal class SameNamespaceXmlWriter : XmlWriter
+    {
+        private readonly XmlWriter _inner;
+        private string _namespace;
+        private bool _start = true;
+
+        public SameNamespaceXmlWriter(XmlWriter inner)
+        {
+            _inner = inner;
+        }
+
+        public override void Flush() => _inner.Flush();
+
+
+        public override string LookupPrefix(string ns) => _inner.LookupPrefix(ns);
+
+        public override void WriteBase64(byte[] buffer, int index, int count) =>
+            _inner.WriteBase64(buffer, index, count);
+
+        public override void WriteCData(string text) => _inner.WriteCData(text);
+
+        public override void WriteCharEntity(char ch) => _inner.WriteCharEntity(ch);
+
+        public override void WriteChars(char[] buffer, int index, int count) => _inner.WriteChars(buffer, index, count);
+
+        public override void WriteComment(string text) => _inner.WriteComment(text);
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset) =>
+            _inner.WriteDocType(name, pubid, sysid, subset);
+
+        public override void WriteEndAttribute() => _inner.WriteEndAttribute();
+
+        public override void WriteEndDocument() => _inner.WriteEndDocument();
+
+        public override void WriteEndElement() => _inner.WriteEndElement();
+
+        public override void WriteEntityRef(string name) => _inner.WriteEntityRef(name);
+
+        public override void WriteFullEndElement() => _inner.WriteFullEndElement();
+
+        public override void WriteProcessingInstruction(string name, string text) =>
+            _inner.WriteProcessingInstruction(name, text);
+
+        public override void WriteRaw(char[] buffer, int index, int count) => _inner.WriteRaw(buffer, index, count);
+
+        public override void WriteRaw(string data) => _inner.WriteRaw(data);
+
+        public override void WriteStartAttribute(string prefix, string localName, string ns) =>
+            _inner.WriteStartAttribute(prefix, localName, ns);
+
+        public override void WriteStartDocument() => _inner.WriteStartDocument();
+
+        public override void WriteStartDocument(bool standalone) => _inner.WriteStartDocument(standalone);
+
+        public override void WriteStartElement(string prefix, string localName, string ns)
+        {
+            if (_start)
+            {
+                _start = false;
+                _namespace = ns;
+            }
+
+            _inner.WriteStartElement(prefix, localName, _namespace);
+        }
+
+        public override void WriteString(string text) => _inner.WriteString(text);
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar) =>
+            _inner.WriteSurrogateCharEntity(lowChar, highChar);
+
+        public override void WriteWhitespace(string ws) => _inner.WriteWhitespace(ws);
+
+        public override WriteState WriteState => _inner.WriteState;
+    }
+}

--- a/CdonMarketplace/Utils/XmlUtils.cs
+++ b/CdonMarketplace/Utils/XmlUtils.cs
@@ -7,37 +7,23 @@ namespace CdonMarketplace.Utils
 {
     public static class XmlUtils
     {
+        private static readonly XmlWriterSettings WriterSettings =
+            new XmlWriterSettings
+            {
+                CloseOutput = false,
+                Encoding = Encoding.UTF8,
+                OmitXmlDeclaration = false,
+                Indent = false
+            };
+
         public static string SerializeXml<T>(T subject)
         {
             using var sw = new Utf8StringWriter();
-            using var xw = new SameNamespaceXmlWriter(sw);
+            using var xw = new SameNamespaceXmlWriter(XmlWriter.Create(sw, WriterSettings));
 
             new XmlSerializer(typeof(T)).Serialize(xw, subject);
 
             return sw.ToString();
-        }
-
-        private class SameNamespaceXmlWriter : XmlTextWriter
-        {
-            private string _namespace;
-            private bool _start = true;
-
-            public SameNamespaceXmlWriter(TextWriter output)
-                : base(output)
-            {
-                Formatting = Formatting.None;
-            }
-
-            public override void WriteStartElement(string prefix, string localName, string ns)
-            {
-                if (_start)
-                {
-                    _start = false;
-                    _namespace = ns;
-                }
-
-                base.WriteStartElement(prefix, localName, _namespace);
-            }
         }
 
         public class Utf8StringWriter : StringWriter


### PR DESCRIPTION
Decorate the xml writer created by XmlWriter.Create instead of inheriting from non-recommended XmlTextWriter.